### PR TITLE
- Fixed bug where we don't get the settings dictionary from the context

### DIFF
--- a/Samples/inRiverCommunity.Extensions.ExtensionSettingsSample/Properties/AssemblyInfo.cs
+++ b/Samples/inRiverCommunity.Extensions.ExtensionSettingsSample/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // Major (may contain breaking changes, new functionality and bug fixes)
 // Minor (may contain new functionality and possible bug fixes)
 // Patch (only contains bug fixes)
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]

--- a/inRiverCommunity.Extensions.Core/Properties/AssemblyInfo.cs
+++ b/inRiverCommunity.Extensions.Core/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // Major (may contain breaking changes, new functionality and bug fixes)
 // Minor (may contain new functionality and possible bug fixes)
 // Patch (only contains bug fixes)
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]

--- a/inRiverCommunity.Extensions.Core/Settings/ExtensionSettings.cs
+++ b/inRiverCommunity.Extensions.Core/Settings/ExtensionSettings.cs
@@ -12,6 +12,18 @@ namespace inRiverCommunity.Extensions.Core.Settings
     public static class ExtensionSettings
     {
 
+
+        /// <summary>
+        /// Initializes or parses a settings dictionary to the settings class of your choosing.
+        /// </summary>
+        /// <typeparam name="T">Your settings class type</typeparam>
+        /// <param name="settingsDictionary">A settings dictionary</param>
+        /// <returns>An initialized settings class</returns>
+        public static T GetSettings<T>(Dictionary<string, string> settingsDictionary = null)
+        {
+            return GetSettings<T>(null, settingsDictionary);
+        }
+
         /// <summary>
         /// Initializes or parses a settings dictionary to the settings class of your choosing.
         /// </summary>
@@ -25,6 +37,11 @@ namespace inRiverCommunity.Extensions.Core.Settings
 
 
             // TODO: Add try catch validation for each setting and gather the collective result for easier validation to the user
+
+
+            // Get the settings dictionary from the context if the context is specified and the passed settings dictionary is null
+            if (settingsDictionary == null && context != null)
+                settingsDictionary = context.Settings;
 
 
             if (settingsDictionary != null && settingsDictionary.Count > 0)
@@ -151,6 +168,17 @@ namespace inRiverCommunity.Extensions.Core.Settings
             return settings;
         }
 
+
+        /// <summary>
+        /// Converts your settings class/object to a settings dictionary.
+        /// </summary>
+        /// <typeparam name="T">Your settings class type</typeparam>
+        /// <param name="settingsObject">An initialized settings class</param>
+        /// <returns>An initialized settings dictionary</returns>
+        public static Dictionary<string, string> GetSettingsAsDictionary<T>(T settingsObject = default)
+        {
+            return GetSettingsAsDictionary<T>(null, settingsObject);
+        }
 
         /// <summary>
         /// Converts your settings class/object to a settings dictionary.

--- a/inRiverCommunity.Extensions.Core/inRiverCommunity.Extensions.Core.nuspec
+++ b/inRiverCommunity.Extensions.Core/inRiverCommunity.Extensions.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>inRiverCommunity.Extensions.Core</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>inRiverCommunity.Extensions.Core</title>
     <authors>inRiverCommunity</authors>
     <owners>inRiverCommunity</owners>


### PR DESCRIPTION
- Added overload methods not requiring the context